### PR TITLE
fix mounting of sample iso

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,6 @@ An example recipe can be found at `<gemu-repo-dir>/gemu/gemuinteractor/example.y
 
 ## Roadmap
 - [ ] per-thread matching of syscall/sysret pairs
-- [ ] prevent unpacking from failing when mounting takes longer than expected
+- [x] prevent unpacking from failing when mounting takes longer than expected
 - [ ] PE-carving
 - [ ] improve .NET unpacking capabilities

--- a/gemu/gemuinteractor/gemu_runner_single_file.py
+++ b/gemu/gemuinteractor/gemu_runner_single_file.py
@@ -155,6 +155,9 @@ class GemuRunnerSingleFile:
             except subprocess.TimeoutExpired:
                 pass
             self.process.kill()
+            # Cleanup ISO directory
+            if self.output_path.parent.exists():
+                shutil.rmtree(self.output_path.parent)
             return self.return_status
             # sys.exit()
 
@@ -248,7 +251,6 @@ class GemuRunnerSingleFile:
             f" copy D:\\{self.sample_name} {user}Desktop\\{self.sample_name}\n",
             self.process,
         )
-        shutil.rmtree(self.output_path.parent)
         self.process.stdin.flush()
         time.sleep(1)
         self.process.stdin.write(b"gemurec\n")


### PR DESCRIPTION
This pr delays the deletion of the ISO directory. This fixes the issue that sample runs fail occasionally, because the virtual device is "not ready".