### PR TITLE
Fix syscall threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ python3 unpack_with_recipe.py --sampleyml recipe.yml
 An example recipe can be found at `<gemu-repo-dir>/gemu/gemuinteractor/example.yml`.
 
 ## Roadmap
-- [ ] per-thread matching of syscall/sysret pairs
+- [x] per-thread matching of syscall/sysret pairs
 - [ ] prevent unpacking from failing when mounting takes longer than expected
 - [ ] PE-carving
 - [ ] improve .NET unpacking capabilities

--- a/gemu/callbacks.c
+++ b/gemu/callbacks.c
@@ -279,12 +279,15 @@ void gemu_cb_sysret(CPUX86State *cpu)
         return;
     }
 
-    if(process->syscall_return_hook.active == false){
-        // sysret without hooked syscall"
+    QWORD pid, tid;
+    get_current_pid_and_tid(cpu_new, &pid, &tid);
+    syscall_hook_t* return_hook = g_hash_table_lookup(process->syscall_return_hooks_by_tid, GINT_TO_POINTER(tid));
+    if(return_hook == NULL || return_hook->active == false){
+        // sysret without hooked syscall
         return;
     }
-    pipe_logger_after_syscall_exec(cpu_new, process);
-    process->syscall_return_hook.active = false;
+    pipe_logger_after_syscall_exec(cpu_new, process, return_hook);
+    return_hook->active = false;
 }
 
 void gemu_cb_after_block_translation(CPUState *cpu, TranslationBlock *tb)

--- a/gemu/callbacks.c
+++ b/gemu/callbacks.c
@@ -22,14 +22,14 @@ long long extracted_data_size = 0;
 
 bool* getWrittenFlagForNode(struct MappedMemoryNode* mmapNode) {
     Gemu *gemu_instance = gemu_get_instance();
-    WinThread* other_thread = get_winthread_for_pid(gemu_instance->win_spec, mmapNode->other_ID);
-    if (other_thread == NULL) {
+    WinProcess* other_process = get_WinProcess_for_pid(gemu_instance->win_spec, mmapNode->other_ID);
+    if (other_process == NULL) {
         return NULL;
     }
     hwaddr start = mmapNode->other_start;
     hwaddr end = mmapNode->other_start + mmapNode->other_size;
 
-    struct Node* current = other_thread->new_sections->head;
+    struct Node* current = other_process->new_sections->head;
     while (current != NULL) {
         if (current->start < end && current->end > start) {
             if (current->is_shared)
@@ -114,7 +114,7 @@ ModuleNode* is_within_range(ModuleNode* head, hwaddr start, hwaddr end) {
 }
 
 
-void check_for_unpacking(CPUState *cpu, TranslationBlock *tb, WinThread *thread, Gemu *gemu_instance){
+void check_for_unpacking(CPUState *cpu, TranslationBlock *tb, WinProcess *process, Gemu *gemu_instance){
     if (counter > 100000 || extracted_data_size > 10e+9) {
         return;
     }
@@ -122,42 +122,42 @@ void check_for_unpacking(CPUState *cpu, TranslationBlock *tb, WinThread *thread,
 
     struct Node* temp_section = NULL;
 
-    if (thread->cache_section == NULL || !(cpu->env_ptr->eip >= thread->cache_section->start && cpu->env_ptr->eip < thread->cache_section->end)){
-        struct Node* temp_section = getNodeForAddress(cpu->env_ptr->eip, thread->new_sections);
-        thread->cache_section = temp_section;
+    if (process->cache_section == NULL || !(cpu->env_ptr->eip >= process->cache_section->start && cpu->env_ptr->eip < process->cache_section->end)){
+        struct Node* temp_section = getNodeForAddress(cpu->env_ptr->eip, process->new_sections);
+        process->cache_section = temp_section;
     }
     else {
-        temp_section = thread->cache_section;
+        temp_section = process->cache_section;
     }
 
     // getting the temp section
 
     if (temp_section == NULL) {
-        thread->cache_section = NULL;
-        print_memory_map(cpu, thread);
-        temp_section = getNodeForAddress(cpu->env_ptr->eip, thread->new_sections);
-        thread->cache_section = temp_section;
+        process->cache_section = NULL;
+        print_memory_map(cpu, process);
+        temp_section = getNodeForAddress(cpu->env_ptr->eip, process->new_sections);
+        process->cache_section = temp_section;
     }
 
     //getting the memory map
 
-    struct SingleLinkedList* list = getMemoryMappedList(gemu_instance->mapped_sections_waitinglist, thread->Process.ID);
+    struct SingleLinkedList* list = getMemoryMappedList(gemu_instance->mapped_sections_waitinglist, process->Process.ID);
     if (list != NULL) {
-        bool list_is_empty = iterateAndUpdateList(list, thread->new_sections);
+        bool list_is_empty = iterateAndUpdateList(list, process->new_sections);
         if (list_is_empty == true) {
-            removeList(gemu_instance->mapped_sections_waitinglist, thread->Process.ID);
+            removeList(gemu_instance->mapped_sections_waitinglist, process->Process.ID);
         }
     }
     if (getWrittenToFlag(temp_section)) {
         struct DoubleLinkedList new_list;
-        copyList(&new_list, thread->new_sections);
+        copyList(&new_list, process->new_sections);
         reduceList(&new_list);
         struct Node* section = getNodeForAddress(cpu->env_ptr->eip, &new_list);
-        if(thread->cache_section_written != NULL && (
-            (thread->cache_section_written->start >= section->start && thread->cache_section_written->start <= section->end) ||
-            (thread->cache_section_written->end >= section->start && thread->cache_section_written->end <= section->end) 
+        if(process->cache_section_written != NULL && (
+            (process->cache_section_written->start >= section->start && process->cache_section_written->start <= section->end) ||
+            (process->cache_section_written->end >= section->start && process->cache_section_written->end <= section->end) 
         ))
-            thread->cache_section_written = NULL;
+            process->cache_section_written = NULL;
 
         uint64_t length = section->end - section->start;
         uint8_t *buf = malloc(length + 1);
@@ -166,16 +166,16 @@ void check_for_unpacking(CPUState *cpu, TranslationBlock *tb, WinThread *thread,
         char filename[261];
         struct timespec now;
         clock_gettime(CLOCK_MONOTONIC_RAW, &now);
-        wi_extract_module_list(cpu, thread);
-        ModuleNode* module = is_within_range(thread->current_modules, temp_section->start, temp_section->end);
+        wi_extract_module_list(cpu, process);
+        ModuleNode* module = is_within_range(process->current_modules, temp_section->start, temp_section->end);
         if (module != NULL) {
-            sprintf(filename, "dumps/%llu_0x%lx_%s_%lu_dump_nr_%d", thread->Process.ID, section->start, module->file,
+            sprintf(filename, "dumps/%llu_0x%lx_%s_%lu_dump_nr_%d", process->Process.ID, section->start, module->file,
                     (now.tv_sec - start_time->tv_sec) * 1000 + (now.tv_nsec - start_time->tv_nsec) / 1000000, counter);
         }
         else{
-            sprintf(filename, "dumps/%llu_0x%lx_mw_%lu_dump_nr_%d", thread->Process.ID, section->start, (now.tv_sec - start_time->tv_sec) * 1000 + (now.tv_nsec - start_time->tv_nsec) / 1000000, counter);
+            sprintf(filename, "dumps/%llu_0x%lx_mw_%lu_dump_nr_%d", process->Process.ID, section->start, (now.tv_sec - start_time->tv_sec) * 1000 + (now.tv_nsec - start_time->tv_nsec) / 1000000, counter);
         }
-        unsetWrittenFlagForRange(section->start, section->end, thread->new_sections);
+        unsetWrittenFlagForRange(section->start, section->end, process->new_sections);
         counter += 1;
         mkdir("dumps", 0777);
         FILE* file = fopen(filename, "wb");
@@ -205,32 +205,32 @@ void gemu_cb_before_tb_exec(CPUState *cpu, TranslationBlock *tb)
        return;
     }
 
-    WinThread *thread = wi_current_thread(gemu_instance->win_spec, cpu, true);
-    if (thread == NULL) {
+    WinProcess *process = wi_current_process(gemu_instance->win_spec, cpu, true);
+    if (process == NULL) {
         // Exit early if the current program is not the one we want to watch
         return;
     }
 
     target_ulong rip = cpu->env_ptr->eip;
-    hkr_try_exec_hook(gemu_instance->hooker, rip, cpu, tb, thread, CB_BEFORE_TB_EXEC);
-    hkr_try_exec_hook(gemu_instance->hooker, rip, cpu, tb, thread, EXIT_FROM_API);
+    hkr_try_exec_hook(gemu_instance->hooker, rip, cpu, tb, process, CB_BEFORE_TB_EXEC);
+    hkr_try_exec_hook(gemu_instance->hooker, rip, cpu, tb, process, EXIT_FROM_API);
 
-    // printf("%llu:E,0x%lx,%i\n", thread->Process.ID, cpu->env_ptr->eip, tb->size);
+    // printf("%llu:E,0x%lx,%i\n", process->Process.ID, cpu->env_ptr->eip, tb->size);
     return;
 }
 
 
-WinProcess* gemu_helper_get_current_process(void){
+WinProcessInner* gemu_helper_get_current_process(void){
 
     Gemu *gemu_instance = gemu_get_instance();
 
     CPUState *cpu_new = current_cpu;
 
-    WinThread *thread = wi_current_thread(gemu_instance->win_spec, cpu_new, true);
-    if (thread == NULL) {
+    WinProcess *process = wi_current_process(gemu_instance->win_spec, cpu_new, true);
+    if (process == NULL) {
         return NULL;
     }
-    return &thread->Process;
+    return &process->Process;
 }
 
 
@@ -248,17 +248,17 @@ void gemu_cb_syscall(CPUX86State *cpu, int next_eip_addend)
 
     CPUState *cpu_new = current_cpu;
 
-    WinThread *thread = wi_current_thread(gemu_instance->win_spec, cpu_new, true);
-    if (thread == NULL || !g_hash_table_contains(gemu_instance->pids_to_lookout_for, GINT_TO_POINTER(thread->Process.ID))) {
+    WinProcess *process = wi_current_process(gemu_instance->win_spec, cpu_new, true);
+    if (process == NULL || !g_hash_table_contains(gemu_instance->pids_to_lookout_for, GINT_TO_POINTER(process->Process.ID))) {
         // Exit early if the current program is not the one we want to watch
         return;
     }
 
-    // char* funcname = lookup_syscall(gemu_instance, &thread->Process, cpu->regs[R_EAX]);
+    // char* funcname = lookup_syscall(gemu_instance, &process->Process, cpu->regs[R_EAX]);
     const char* funcname2 = SYSCALL_NAMES[syscall_enum];
     
     printf("SYSCALL: %lx %s\n", cpu->regs[R_EAX], funcname2);
-    pipe_logger_before_syscall_exec_enum(cpu_new, syscall_enum, thread);
+    pipe_logger_before_syscall_exec_enum(cpu_new, syscall_enum, process);
 
     //printf("%llu:E,0x%lx,%i\n", thread->Process.ID, cpu->env_ptr->eip, tb->size);
     return;
@@ -273,18 +273,18 @@ void gemu_cb_sysret(CPUX86State *cpu)
 
     CPUState *cpu_new = current_cpu;
 
-    WinThread *thread = wi_current_thread(gemu_instance->win_spec, cpu_new, true);
-    if (thread == NULL || !g_hash_table_contains(gemu_instance->pids_to_lookout_for, GINT_TO_POINTER(thread->Process.ID))) {
+    WinProcess *process = wi_current_process(gemu_instance->win_spec, cpu_new, true);
+    if (process == NULL || !g_hash_table_contains(gemu_instance->pids_to_lookout_for, GINT_TO_POINTER(process->Process.ID))) {
         // Exit early if the current program is not the one we want to watch
         return;
     }
 
-    if(thread->syscall_return_hook.active == false){
+    if(process->syscall_return_hook.active == false){
         // sysret without hooked syscall"
         return;
     }
-    pipe_logger_after_syscall_exec(cpu_new, thread);
-    thread->syscall_return_hook.active = false;
+    pipe_logger_after_syscall_exec(cpu_new, process);
+    process->syscall_return_hook.active = false;
 }
 
 void gemu_cb_after_block_translation(CPUState *cpu, TranslationBlock *tb)
@@ -294,8 +294,8 @@ void gemu_cb_after_block_translation(CPUState *cpu, TranslationBlock *tb)
     }
 
     Gemu *gemu_instance = gemu_get_instance();
-    WinThread *thread = wi_current_thread(gemu_instance->win_spec, cpu, true);
-    if (thread == NULL) {
+    WinProcess *process = wi_current_process(gemu_instance->win_spec, cpu, true);
+    if (process == NULL) {
         // Exit early if the current program is not the one we want to watch
         return;
     }
@@ -303,10 +303,10 @@ void gemu_cb_after_block_translation(CPUState *cpu, TranslationBlock *tb)
     //QWORD processid;
     //QWORD threadid;
     //get_current_pid_and_tid(cpu, &processid, &threadid);
-    //printf("%llu:%llu:B:0x%lx,%i\n", thread->Process.ID, threadid, cpu->env_ptr->eip, tb->size);
-    //printf("%llu:B:0x%lx,%i\n", thread->Process.ID, cpu->env_ptr->eip, tb->size);
+    //printf("%llu:%llu:B:0x%lx,%i\n", process->Process.ID, threadid, cpu->env_ptr->eip, tb->size);
+    //printf("%llu:B:0x%lx,%i\n", process->Process.ID, cpu->env_ptr->eip, tb->size);
 
-    check_for_unpacking(cpu, tb, thread, gemu_instance);
+    check_for_unpacking(cpu, tb, process, gemu_instance);
 }
 
 
@@ -320,28 +320,28 @@ void gemu_cb_phys_memory_written(CPUArchState *env, target_ulong addr, uint64_t 
 
     Gemu *gemu_instance = gemu_get_instance();
 
-    WinThread *thread = wi_current_thread(gemu_instance->win_spec, cpu, true);
-    if (thread == NULL) {
+    WinProcess *process = wi_current_process(gemu_instance->win_spec, cpu, true);
+    if (process == NULL) {
         // Exit early if the current program is not the one we want to watch
         return;
     }
 
-    if(thread->cache_section_written != NULL && addr >= thread->cache_section_written->start && addr <= thread->cache_section_written->end)
+    if(process->cache_section_written != NULL && addr >= process->cache_section_written->start && addr <= process->cache_section_written->end)
         return;
-    struct Node* section = getNodeForAddress(addr, thread->new_sections);
+    struct Node* section = getNodeForAddress(addr, process->new_sections);
 
     if (section == NULL) {
-        thread->cache_section = NULL;
-        print_memory_map(cpu, thread);
-        section = getNodeForAddress(addr, thread->new_sections);
+        process->cache_section = NULL;
+        print_memory_map(cpu, process);
+        section = getNodeForAddress(addr, process->new_sections);
     }
-    thread->cache_section_written = section;
+    process->cache_section_written = section;
 
-    struct SingleLinkedList* list = getMemoryMappedList(gemu_instance->mapped_sections_waitinglist, thread->Process.ID);
+    struct SingleLinkedList* list = getMemoryMappedList(gemu_instance->mapped_sections_waitinglist, process->Process.ID);
     if (list != NULL) {
-        bool list_is_empty = iterateAndUpdateList(list, thread->new_sections);
+        bool list_is_empty = iterateAndUpdateList(list, process->new_sections);
         if (list_is_empty == true) {
-            removeList(gemu_instance->mapped_sections_waitinglist, thread->Process.ID);
+            removeList(gemu_instance->mapped_sections_waitinglist, process->Process.ID);
         }
     }
 
@@ -356,10 +356,10 @@ void update_memory_map_from_env(CPUArchState *env){
         return;
     }
     Gemu *gemu_instance = gemu_get_instance();
-    WinThread *thread = wi_current_thread(gemu_instance->win_spec, cpu, true);
-    if (thread == NULL) {
+    WinProcess *process = wi_current_process(gemu_instance->win_spec, cpu, true);
+    if (process == NULL) {
         // Exit early if the current program is not the one we want to watch
         return;
     }
-    print_memory_map(cpu, thread);
+    print_memory_map(cpu, process);
 }

--- a/gemu/callbacks.c
+++ b/gemu/callbacks.c
@@ -215,6 +215,7 @@ void gemu_cb_before_tb_exec(CPUState *cpu, TranslationBlock *tb)
     hkr_try_exec_hook(gemu_instance->hooker, rip, cpu, tb, thread, CB_BEFORE_TB_EXEC);
     hkr_try_exec_hook(gemu_instance->hooker, rip, cpu, tb, thread, EXIT_FROM_API);
 
+    // printf("%llu:E,0x%lx,%i\n", thread->Process.ID, cpu->env_ptr->eip, tb->size);
     return;
 }
 

--- a/gemu/callbacks.c
+++ b/gemu/callbacks.c
@@ -303,8 +303,7 @@ void gemu_cb_after_block_translation(CPUState *cpu, TranslationBlock *tb)
     //QWORD processid;
     //QWORD threadid;
     //get_current_pid_and_tid(cpu, &processid, &threadid);
-    //printf("%llu:%llu:B:0x%lx,%i\n", thread->Process.ID, thread->ThreadId, cpu->env_ptr->eip, tb->size);
-    //thread->ThreadId = threadid;
+    //printf("%llu:%llu:B:0x%lx,%i\n", thread->Process.ID, threadid, cpu->env_ptr->eip, tb->size);
     //printf("%llu:B:0x%lx,%i\n", thread->Process.ID, cpu->env_ptr->eip, tb->size);
 
     check_for_unpacking(cpu, tb, thread, gemu_instance);

--- a/gemu/gemu.c
+++ b/gemu/gemu.c
@@ -622,8 +622,7 @@ void pipe_logger_after_syscall_exec(CPUState *cpu, WinThread* thread) {
         output = read_out_parameters64(gemu, cpu, func_name, dll_name,
                                        number_of_outparameters, out_parameters, thread);
     }
-    printf("%llu:%llu:$-%s -> %li\n", thread->Process.ID, thread->ThreadId,
-           cJSON_PrintUnformatted(output), ret);
+    printf("%llu:%llu:$-%s -> %li\n", thread->Process.ID, (unsigned long long)0, cJSON_PrintUnformatted(output), ret);
 
     switch (hook->syscall_enum)
     {
@@ -663,8 +662,7 @@ static void pipe_logger_after_tb_exec(target_ulong pc, CPUState *cpu,
         output = read_out_parameters64(gemu, cpu, func_name, dll_name,
                                        number_of_outparameters, out_parameters, thread);
     }
-    printf("%llu:%llu:$-%s -> %li\n", thread->Process.ID, thread->ThreadId,
-           cJSON_PrintUnformatted(output), ret);
+    printf("%llu:%llu:$-%s -> %li\n", thread->Process.ID, (unsigned long long)0, cJSON_PrintUnformatted(output), ret);
 
     //load library is always interesting, for DOTNET and WINAPI case
     if (unlikely(strncmp(func_name, "LoadLibrary", 11) == 0)) {
@@ -974,8 +972,7 @@ void pipe_logger_before_syscall_exec_enum(CPUState *cpu,
                 read_parameters64(gemu_instance, cpu, func_name, dll_name, &newHook_ptr->out_parameter_list, thread);
     }
 
-    printf("%llu:%llu:$+%s\n", thread->Process.ID, thread->ThreadId,
-           cJSON_PrintUnformatted(output));
+    printf("%llu:%llu:$+%s\n", thread->Process.ID, (unsigned long long)0, cJSON_PrintUnformatted(output));
     cJSON_Delete(output);
 }
 
@@ -1026,8 +1023,7 @@ static void pipe_logger_before_tb_exec(target_ulong pc, CPUState *cpu,
                 read_parameters64(gemu_instance, cpu, func_name, dll_name, &newHook.out_parameter_list, thread);
     }
 
-    printf("%llu:%llu:$+%s\n", thread->Process.ID, thread->ThreadId,
-           cJSON_PrintUnformatted(output));
+    printf("%llu:%llu:$+%s\n", thread->Process.ID, (unsigned long long)0, cJSON_PrintUnformatted(output));
 
     if (unlikely(strncmp(func_name, "LoadLibrary", 11) == 0)) {
         handle_special_apis(gemu_instance, cpu, dll_name, func_name, thread, &newHook.out_parameter_list, is32bit);

--- a/gemu/gemu.c
+++ b/gemu/gemu.c
@@ -668,14 +668,6 @@ static void pipe_logger_after_tb_exec(target_ulong pc, CPUState *cpu,
 
     //load library is always interesting, for DOTNET and WINAPI case
     if (unlikely(strncmp(func_name, "LoadLibrary", 11) == 0)) {
-        gpointer stack_depth = g_hash_table_lookup(thread->Process.stack_depth, &thread->ThreadId);
-        if (stack_depth == NULL) {
-            stack_depth = 0;
-        }
-        else {
-            stack_depth -= 1;
-        }
-        g_hash_table_insert(thread->Process.stack_depth, &thread->ThreadId, stack_depth);
         wi_extract_module_list(cpu, thread);
         handle_loaded_library(thread->current_modules);
         // print_module_nodes(thread->current_modules);
@@ -1039,12 +1031,6 @@ static void pipe_logger_before_tb_exec(target_ulong pc, CPUState *cpu,
 
     if (unlikely(strncmp(func_name, "LoadLibrary", 11) == 0)) {
         handle_special_apis(gemu_instance, cpu, dll_name, func_name, thread, &newHook.out_parameter_list, is32bit);
-        gpointer stack_depth = g_hash_table_lookup(thread->Process.stack_depth, &thread->ThreadId);
-        if (stack_depth == NULL) {
-            stack_depth = 0;
-        }
-        stack_depth += 1;
-        g_hash_table_insert(thread->Process.stack_depth, &thread->ThreadId, stack_depth);
     }
 
     if (hkr_add_new_hook(gemu_instance->hooker, newHook) && newHook.addr != 0) {

--- a/gemu/hooks.c
+++ b/gemu/hooks.c
@@ -85,7 +85,7 @@ void* find_cb_func(hook_t *hook, enum callback cb)
 
 // Calls the callback function if address is hooked.
 // Returns True if hook was found, False if address is not hooked
-bool hkr_try_exec_hook(Hooker *h, target_ulong address, CPUState *cpu, TranslationBlock *tb, WinThread *thread, enum callback cb)
+bool hkr_try_exec_hook(Hooker *h, target_ulong address, CPUState *cpu, TranslationBlock *tb, WinProcess *process, enum callback cb)
 {
     hook_t lookup_hook = {
             .addr = address,
@@ -102,7 +102,7 @@ bool hkr_try_exec_hook(Hooker *h, target_ulong address, CPUState *cpu, Translati
     }
 
     int n = found_hook->out_parameter_list.number_of_outparameters;
-    cb_func(address, cpu, tb, found_hook->dll_name, found_hook->func_name, thread, found_hook->out_parameter_list.out_parameters, n, found_hook->is32bit);
+    cb_func(address, cpu, tb, found_hook->dll_name, found_hook->func_name, process, found_hook->out_parameter_list.out_parameters, n, found_hook->is32bit);
     return true;
 }
 

--- a/gemu/syscalltable.c
+++ b/gemu/syscalltable.c
@@ -3,7 +3,7 @@
 
 #include <stdio.h>
 
-static const cJSON *get_syscalls_for_build(Gemu *gemu_instance, const WinProcess* process) {
+static const cJSON *get_syscalls_for_build(Gemu *gemu_instance, const WinProcessInner* process) {
     // TODO(OPTIMIZE): This build number lookup and string conversion needs to be done only once
     //                 since it cannot change between processes on the same guest.
     const int build_number = process->PEB.OSBuildNumber;
@@ -18,7 +18,7 @@ static const cJSON *get_syscalls_for_build(Gemu *gemu_instance, const WinProcess
     return syscalls_for_build;
 }
 
-const char *lookup_syscall(Gemu *gemu_instance, const WinProcess* process, const int syscall_number) {
+const char *lookup_syscall(Gemu *gemu_instance, const WinProcessInner* process, const int syscall_number) {
     const cJSON *syscalls_for_build = gemu_instance->syscall_lookup_for_build;
     if(!syscalls_for_build){
         syscalls_for_build = get_syscalls_for_build(gemu_instance, process);
@@ -44,7 +44,7 @@ const char *lookup_syscall(Gemu *gemu_instance, const WinProcess* process, const
 
 
 
-static GHashTable *get_syscalls_for_build_enum(Gemu *gemu_instance, const WinProcess* process) {
+static GHashTable *get_syscalls_for_build_enum(Gemu *gemu_instance, const WinProcessInner* process) {
     const cJSON *syscalls_for_build = get_syscalls_for_build(gemu_instance, process);
     // TODO: Free
     GHashTable* syscalls_for_build_enum = g_hash_table_new(g_direct_hash, g_direct_equal);
@@ -65,10 +65,10 @@ static GHashTable *get_syscalls_for_build_enum(Gemu *gemu_instance, const WinPro
 } 
 
 
-syscall_t lookup_syscall_enum(Gemu *gemu_instance, const int syscall_number, WinProcess* (*get_process) (void)) {
+syscall_t lookup_syscall_enum(Gemu *gemu_instance, const int syscall_number, WinProcessInner* (*get_process) (void)) {
     const GHashTable *syscalls_for_build_enum = gemu_instance->syscall_lookup_for_build_enum;
     if(!syscalls_for_build_enum){
-        WinProcess * process = get_process();
+        WinProcessInner * process = get_process();
         if(!process){
             return UNKNOWN_SYSCALL;
         }

--- a/gemu/syscalltable.c
+++ b/gemu/syscalltable.c
@@ -3,7 +3,7 @@
 
 #include <stdio.h>
 
-static const cJSON *get_syscalls_for_build(Gemu *gemu_instance, const WinProcessInner* process) {
+static const cJSON *get_syscalls_for_build(Gemu *gemu_instance, const WinProcess* process) {
     // TODO(OPTIMIZE): This build number lookup and string conversion needs to be done only once
     //                 since it cannot change between processes on the same guest.
     const int build_number = process->PEB.OSBuildNumber;
@@ -18,7 +18,7 @@ static const cJSON *get_syscalls_for_build(Gemu *gemu_instance, const WinProcess
     return syscalls_for_build;
 }
 
-const char *lookup_syscall(Gemu *gemu_instance, const WinProcessInner* process, const int syscall_number) {
+const char *lookup_syscall(Gemu *gemu_instance, const WinProcess* process, const int syscall_number) {
     const cJSON *syscalls_for_build = gemu_instance->syscall_lookup_for_build;
     if(!syscalls_for_build){
         syscalls_for_build = get_syscalls_for_build(gemu_instance, process);
@@ -44,7 +44,7 @@ const char *lookup_syscall(Gemu *gemu_instance, const WinProcessInner* process, 
 
 
 
-static GHashTable *get_syscalls_for_build_enum(Gemu *gemu_instance, const WinProcessInner* process) {
+static GHashTable *get_syscalls_for_build_enum(Gemu *gemu_instance, const WinProcess* process) {
     const cJSON *syscalls_for_build = get_syscalls_for_build(gemu_instance, process);
     // TODO: Free
     GHashTable* syscalls_for_build_enum = g_hash_table_new(g_direct_hash, g_direct_equal);
@@ -65,10 +65,10 @@ static GHashTable *get_syscalls_for_build_enum(Gemu *gemu_instance, const WinPro
 } 
 
 
-syscall_t lookup_syscall_enum(Gemu *gemu_instance, const int syscall_number, WinProcessInner* (*get_process) (void)) {
+syscall_t lookup_syscall_enum(Gemu *gemu_instance, const int syscall_number, WinProcess* (*get_process) (void)) {
     const GHashTable *syscalls_for_build_enum = gemu_instance->syscall_lookup_for_build_enum;
     if(!syscalls_for_build_enum){
-        WinProcessInner * process = get_process();
+        WinProcess* process = get_process();
         if(!process){
             return UNKNOWN_SYSCALL;
         }

--- a/gemu/win_spector.c
+++ b/gemu/win_spector.c
@@ -247,7 +247,7 @@ WinProcess *wi_extract_process_from_memory(WindowsIntrospecter *w, CPUState *cpu
       .cache_section_written = NULL,
       .current_modules = NULL,
       .bitness = BITNESS_UNKNOWN,
-      .syscall_return_hook.active = false
+      .syscall_return_hooks_by_tid = g_hash_table_new(NULL, NULL)
   };
   newThread.is_excluded = is_process_excluded(w, &newThread);
   *newThreadPtr = newThread;

--- a/gemu/win_spector.c
+++ b/gemu/win_spector.c
@@ -115,12 +115,14 @@ WinThread *wi_current_thread(WindowsIntrospecter *w, CPUState *cpu,
                              bool add_thread) {
   target_ulong asid = cpu->env_ptr->cr[3];
   // WinProcess is cached
-  WinThread cmpThread = {0,
-                         {
-                             .ID = 0,
-                             .ASID = asid,
-                         },
-                         false};
+  WinThread cmpThread = {
+      .Process = {
+          .ID = 0,
+          .ASID = asid,
+      },
+      .is_excluded = false
+  };
+
   WinThread *thread =
       (WinThread *)qht_lookup(w->asid_winthread_map, &cmpThread, asid);
 
@@ -227,7 +229,6 @@ WinThread *wi_extract_thread_from_memory(WindowsIntrospecter *w, CPUState *cpu,
 
   WinThread *newThreadPtr = malloc(sizeof(WinThread));
   WinThread newThread = {
-      .ThreadId = teb.ClientId.ThreadId,
       .process_handles = g_hash_table_new(NULL, NULL),
       .section_handles = g_hash_table_new(NULL, NULL),
       .Process =

--- a/gemu/win_spector.c
+++ b/gemu/win_spector.c
@@ -115,14 +115,14 @@ WinProcess *wi_current_process(WindowsIntrospecter *w, CPUState *cpu,
                              bool add_process) {
   target_ulong asid = cpu->env_ptr->cr[3];
   // WinProcess is cached
-  WinProcess cmpThread = {
+  WinProcess cmpProcess = {
       .ID = 0,
       .ASID = asid,
       .is_excluded = false
   };
 
   WinProcess *process =
-      (WinProcess *)qht_lookup(w->asid_winprocess_map, &cmpThread, asid);
+      (WinProcess *)qht_lookup(w->asid_winprocess_map, &cmpProcess, asid);
 
   if (!process) {
     // WinProcess is not cached, add it to cache

--- a/include/gemu/callbacks.h
+++ b/include/gemu/callbacks.h
@@ -17,7 +17,7 @@ void gemu_cb_after_block_translation(CPUState *cpu, TranslationBlock *tb);
 
 void update_memory_map_from_env(CPUArchState *env);
 
-void check_for_unpacking(CPUState *cpu, TranslationBlock *tb, WinThread *thread, Gemu *gemu_instance);
+void check_for_unpacking(CPUState *cpu, TranslationBlock *tb, WinProcess *thread, Gemu *gemu_instance);
 
 bool iterateAndUpdateList(struct SingleLinkedList* singleList, struct DoubleLinkedList* doubleList);
 
@@ -25,7 +25,7 @@ bool convertToSharedWrittenBit(struct MappedMemoryNode* mmapNode, struct DoubleL
 
 bool* getWrittenFlagForNode(struct MappedMemoryNode* mmapNode);
 
-WinProcess* gemu_helper_get_current_process(void);
+WinProcessInner* gemu_helper_get_current_process(void);
 
 void gemu_cb_syscall(CPUX86State *cpu, int next_eip_addend);
 

--- a/include/gemu/callbacks.h
+++ b/include/gemu/callbacks.h
@@ -25,7 +25,7 @@ bool convertToSharedWrittenBit(struct MappedMemoryNode* mmapNode, struct DoubleL
 
 bool* getWrittenFlagForNode(struct MappedMemoryNode* mmapNode);
 
-WinProcessInner* gemu_helper_get_current_process(void);
+WinProcess* gemu_helper_get_current_process(void);
 
 void gemu_cb_syscall(CPUX86State *cpu, int next_eip_addend);
 

--- a/include/gemu/gemu.h
+++ b/include/gemu/gemu.h
@@ -134,7 +134,7 @@ void pipe_logger_before_syscall_exec_enum(CPUState *cpu,
                                      syscall_t syscall, WinProcess *process);
 
 
-void pipe_logger_after_syscall_exec(CPUState *cpu, WinProcess* process);
+void pipe_logger_after_syscall_exec(CPUState *cpu, WinProcess* process, syscall_hook_t* hook);
 
 void gemu_start_recording(void);
 

--- a/include/gemu/gemu.h
+++ b/include/gemu/gemu.h
@@ -55,45 +55,45 @@ Gemu *gemu_get_instance(void);
 void gemu_destroy(void);
 
 bool handle_special_apis(Gemu *gemu_instance, CPUState *cpu, const char *dll_name,
-                         const char *func_name, WinThread *thread, out_parameter_list_t* out_parameter_list,
+                         const char *func_name, WinProcess *process, out_parameter_list_t* out_parameter_list,
                          bool is32Bit);
 
-void handle_ZwWriteFile(Gemu *gemu_instance, CPUState *cpu, WinThread *thread,
+void handle_ZwWriteFile(Gemu *gemu_instance, CPUState *cpu, WinProcess *process,
                         const char *dll_name, const char *func_name, out_parameter_list_t* out_parameter_list,
                         bool is32Bit);
 
 void handle_ZwWriteVirtualMemory(Gemu *gemu_instance, CPUState *cpu,
-                                 WinThread *thread, const char *dll_name,
+                                 WinProcess *process, const char *dll_name,
                                  const char *func_name, out_parameter_list_t* out_parameter_list, bool is32Bit);
 
 void handle_ZwTerminateProcess(Gemu *gemu_instance, CPUState *cpu,
-                               WinThread *thread, const char *dll_name,
+                               WinProcess *process, const char *dll_name,
                                const char *func_name, out_parameter_list_t* out_parameter_list, bool is32Bit);
 
-void handle_ZwMapViewOfSection_exit(Gemu *gemu_instance, WinThread *thread,
+void handle_ZwMapViewOfSection_exit(Gemu *gemu_instance, WinProcess *process,
                                     cJSON *output);
 
-void handle_ZwOpenProcess_Exit(cJSON *output, WinThread *thread);
+void handle_ZwOpenProcess_Exit(cJSON *output, WinProcess *process);
 
 cJSON *read_out_parameters64(Gemu *gemu, CPUState *cpu, const char *func_name,
                              const char *dll_name, int number_of_outparameters,
-                             out_parameter out_parameters[], WinThread *thread);
+                             out_parameter out_parameters[], WinProcess *process);
 
 cJSON *read_out_parameters32(Gemu *gemu, CPUState *cpu, const char *func_name,
                              const char *dll_name, int number_of_outparameters,
-                             out_parameter out_parameters[], WinThread *thread);
+                             out_parameter out_parameters[], WinProcess *process);
 
 cJSON *read_parameters32(Gemu *gemu_instance, CPUState *cpu, const char *func_name,
-                         const char *dll_name, out_parameter_list_t* out_parameter_list, WinThread *thread);
+                         const char *dll_name, out_parameter_list_t* out_parameter_list, WinProcess *process);
 
 cJSON *read_parameters64(Gemu *gemu_instance, CPUState *cpu, const char *func_name,
-                         const char *dll_name, out_parameter_list_t *out_parameter_list, WinThread *thread);
+                         const char *dll_name, out_parameter_list_t *out_parameter_list, WinProcess *process);
 
 void fill_processinformation64(CPUState *cpu, QWORD value,
-                               cJSON *processinformation, WinThread *thread);
+                               cJSON *processinformation, WinProcess *process);
 
 void fill_processinformation32(CPUState *cpu, QWORD value,
-                               cJSON *processinformation, WinThread *thread);
+                               cJSON *processinformation, WinProcess *process);
 
 QWORD get_parameter64(CPUState *cpu, int index);
 
@@ -109,9 +109,9 @@ int count_dereferences(char *s);
 
 char *read_file(const char *filename);
 
-void wi_extract_module_list(CPUState *cpu, WinThread *thread);
+void wi_extract_module_list(CPUState *cpu, WinProcess *process);
 
-void dump_WriteVirtualMemory(cJSON *output, CPUState *cpu, WinThread *thread,
+void dump_WriteVirtualMemory(cJSON *output, CPUState *cpu, WinProcess *process,
                              int pid);
 
 bool insert_sorted_module_node(ModuleNode **head, ModuleNode *new_node);
@@ -128,13 +128,13 @@ void insert_sorted(Module **head, Module *new_module);
 
 Module *parse_modules(const char *filename);
 
-void try_extract_kernel32_address(Gemu *gemu_instance, CPUState *cpu, WinThread *thread);
+void try_extract_kernel32_address(Gemu *gemu_instance, CPUState *cpu, WinProcess *process);
 
 void pipe_logger_before_syscall_exec_enum(CPUState *cpu,
-                                     syscall_t syscall, WinThread *thread);
+                                     syscall_t syscall, WinProcess *process);
 
 
-void pipe_logger_after_syscall_exec(CPUState *cpu, WinThread* thread);
+void pipe_logger_after_syscall_exec(CPUState *cpu, WinProcess* process);
 
 void gemu_start_recording(void);
 

--- a/include/gemu/hooks.h
+++ b/include/gemu/hooks.h
@@ -36,7 +36,7 @@ typedef struct
 } hook_t;
 
 typedef void (*hook_callback_func)(target_ulong pc, CPUState *cpu, TranslationBlock *tb, char *dll_name,
-                                   char *func_name, WinThread *thread, out_parameter out_parameters[], int number_of_outparameters, bool is32bit);
+                                   char *func_name, WinProcess *process, out_parameter out_parameters[], int number_of_outparameters, bool is32bit);
 
 typedef struct
 {
@@ -55,7 +55,7 @@ bool hkr_add_new_hook(Hooker *h, hook_t hook);
 
 bool hkr_remove_hook(Hooker *h, target_ulong pc);
 
-bool hkr_try_exec_hook(Hooker *h, target_ulong address, CPUState *cpu, TranslationBlock *tb, WinThread *thread, enum callback cb);
+bool hkr_try_exec_hook(Hooker *h, target_ulong address, CPUState *cpu, TranslationBlock *tb, WinProcess *process, enum callback cb);
 
 void* find_cb_func(hook_t *hook, enum callback cb);
 

--- a/include/gemu/syscalltable.h
+++ b/include/gemu/syscalltable.h
@@ -6,8 +6,8 @@
 #include "glib.h"
 
 // Return char must not be freed, it lives inside the loaded cJSON lookup table.
-const char *lookup_syscall(Gemu *gemu_instance, const WinProcessInner* process, const int syscall_number);
+const char *lookup_syscall(Gemu *gemu_instance, const WinProcess* process, const int syscall_number);
 
-syscall_t lookup_syscall_enum(Gemu *gemu_instance, const int syscall_number, WinProcessInner* (*get_process) (void));
+syscall_t lookup_syscall_enum(Gemu *gemu_instance, const int syscall_number, WinProcess* (*get_process) (void));
 
 #endif //GEMU_SYSCALLTABLE_H

--- a/include/gemu/syscalltable.h
+++ b/include/gemu/syscalltable.h
@@ -6,8 +6,8 @@
 #include "glib.h"
 
 // Return char must not be freed, it lives inside the loaded cJSON lookup table.
-const char *lookup_syscall(Gemu *gemu_instance, const WinProcess* process, const int syscall_number);
+const char *lookup_syscall(Gemu *gemu_instance, const WinProcessInner* process, const int syscall_number);
 
-syscall_t lookup_syscall_enum(Gemu *gemu_instance, const int syscall_number, WinProcess* (*get_process) (void));
+syscall_t lookup_syscall_enum(Gemu *gemu_instance, const int syscall_number, WinProcessInner* (*get_process) (void));
 
 #endif //GEMU_SYSCALLTABLE_H

--- a/include/gemu/win_spector.h
+++ b/include/gemu/win_spector.h
@@ -60,15 +60,6 @@ typedef struct _Module_List {
     DWORD Size;
 } Module_List;
 
-typedef struct
-{
-    unsigned long long int ID; // ProcessID
-    char *ImagePathName; // ProcessName
-    ASID ASID;
-    PEB64 PEB;
-    RTL_USER_PROCESS_PARAMETERS64 ProcessParameters;
-    struct Module_List *module_list;
-} WinProcessInner;
 
 typedef enum {BITNESS_UNKNOWN = 0, BITNESS_32 = 1, BITNESS_64 = 2} Bitness;
 
@@ -93,7 +84,12 @@ typedef struct
 } syscall_hook_t;
 typedef struct
 {
-    WinProcessInner Process;
+    unsigned long long int ID; // ProcessID
+    char *ImagePathName; // ProcessName
+    ASID ASID;
+    PEB64 PEB;
+    RTL_USER_PROCESS_PARAMETERS64 ProcessParameters;
+    struct Module_List *module_list;
     bool is_excluded;
     void* process_handles;
     void* section_handles;

--- a/include/gemu/win_spector.h
+++ b/include/gemu/win_spector.h
@@ -103,7 +103,8 @@ typedef struct
     struct Node* cache_section_written;
     void* current_modules;
     Bitness bitness;
-    syscall_hook_t syscall_return_hook;
+    void* syscall_return_hooks_by_tid;
+    //syscall_hook_t syscall_return_hook;
 } WinProcess;
 
 typedef struct

--- a/include/gemu/win_spector.h
+++ b/include/gemu/win_spector.h
@@ -93,7 +93,6 @@ typedef struct
 } syscall_hook_t;
 typedef struct
 {
-    unsigned long long int ThreadId;
     WinProcess Process;
     bool is_excluded;
     void* process_handles;

--- a/include/gemu/win_spector.h
+++ b/include/gemu/win_spector.h
@@ -68,7 +68,6 @@ typedef struct
     PEB64 PEB;
     RTL_USER_PROCESS_PARAMETERS64 ProcessParameters;
     struct Module_List *module_list;
-    GHashTable *stack_depth;
 } WinProcess;
 
 typedef enum {BITNESS_UNKNOWN = 0, BITNESS_32 = 1, BITNESS_64 = 2} Bitness;
@@ -135,15 +134,10 @@ void get_current_pid_and_tid(CPUState *cpu, QWORD *processid, QWORD *threadid);
 
 void get_pid_and_tid_from_teb_address(target_ulong teb_address, CPUState *cpu, QWORD *processid, QWORD *threadid);
 
-char* get_stack_depth_indicator(WinThread *thread);
-
 void print_memory_map(CPUState *cpu, WinThread *thread);
 
 bool is_thread_excluded(WindowsIntrospecter *w, WinThread *t);
 
 struct qht *init_asid_winthread_map(int bucket_size);
-
-void free_value(gpointer data);
-
 
 #endif //GEMU_WIN_SPECTOR_HPP

--- a/include/gemu/win_spector.h
+++ b/include/gemu/win_spector.h
@@ -68,7 +68,7 @@ typedef struct
     PEB64 PEB;
     RTL_USER_PROCESS_PARAMETERS64 ProcessParameters;
     struct Module_List *module_list;
-} WinProcess;
+} WinProcessInner;
 
 typedef enum {BITNESS_UNKNOWN = 0, BITNESS_32 = 1, BITNESS_64 = 2} Bitness;
 
@@ -93,7 +93,7 @@ typedef struct
 } syscall_hook_t;
 typedef struct
 {
-    WinProcess Process;
+    WinProcessInner Process;
     bool is_excluded;
     void* process_handles;
     void* section_handles;
@@ -104,12 +104,12 @@ typedef struct
     void* current_modules;
     Bitness bitness;
     syscall_hook_t syscall_return_hook;
-} WinThread;
+} WinProcess;
 
 typedef struct
 {
-    struct qht *asid_winthread_map;
-    void* pid_winthread_map;
+    struct qht *asid_winprocess_map;
+    void* pid_winprocess_map;
     char *watched_programs;
 } WindowsIntrospecter;
 
@@ -119,24 +119,24 @@ WindowsIntrospecter *init_windows_introspecter(int bucket_size, const char *watc
 
 void wi_destroy(WindowsIntrospecter *w);
 
-void wi_add_thread(WindowsIntrospecter *w, target_ulong asid, WinThread *winthread);
+void wi_add_process(WindowsIntrospecter *w, target_ulong asid, WinProcess *WinProcess);
 
-WinThread *wi_current_thread(WindowsIntrospecter *w, CPUState *cpu, bool addthread);
+WinProcess *wi_current_process(WindowsIntrospecter *w, CPUState *cpu, bool addthread);
 
-WinThread *wi_extract_thread_from_memory(WindowsIntrospecter *w, CPUState *cpu, target_ulong asid);
+WinProcess *wi_extract_process_from_memory(WindowsIntrospecter *w, CPUState *cpu, target_ulong asid);
 
-WinThread *wi_extract_thread_from_memory_with_env(WindowsIntrospecter *w, CPUArchState *env, target_ulong asid);
+WinProcess *wi_extract_process_from_memory_with_env(WindowsIntrospecter *w, CPUArchState *env, target_ulong asid);
 
-WinThread *get_winthread_for_pid(WindowsIntrospecter *w, target_ulong id);
+WinProcess *get_WinProcess_for_pid(WindowsIntrospecter *w, target_ulong id);
 
 void get_current_pid_and_tid(CPUState *cpu, QWORD *processid, QWORD *threadid);
 
 void get_pid_and_tid_from_teb_address(target_ulong teb_address, CPUState *cpu, QWORD *processid, QWORD *threadid);
 
-void print_memory_map(CPUState *cpu, WinThread *thread);
+void print_memory_map(CPUState *cpu, WinProcess *thread);
 
-bool is_thread_excluded(WindowsIntrospecter *w, WinThread *t);
+bool is_process_excluded(WindowsIntrospecter *w, WinProcess *p);
 
-struct qht *init_asid_winthread_map(int bucket_size);
+struct qht *init_asid_WinProcess_map(int bucket_size);
 
 #endif //GEMU_WIN_SPECTOR_HPP


### PR DESCRIPTION
This pr merges WinThread and WinProcess, removes the ThreadId from the struct and makes sure that syscall/sysret matching is done with correctly retrieved TIDs.

The previous implementation occasionally handled simultaneous syscalls from two threads of the same process wrong.